### PR TITLE
fix: detect signed in state manually

### DIFF
--- a/src/lib/components/header/AccountDropdown.svelte
+++ b/src/lib/components/header/AccountDropdown.svelte
@@ -3,12 +3,15 @@ import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
 import { User } from "carbon-icons-svelte";
 import { authClient } from "$lib/auth-client";
 
-const session = authClient.useSession();
-let signedIn: boolean = $derived($session?.data !== null);
+let loggedIn = $state(false);
+let open = $state(false);
 </script>
 
-<OverflowMenu icon={User} flipped>
-    {#if signedIn}
+<OverflowMenu bind:open={open} icon={User} flipped on:click={async () => {
+    if (open) return;
+    loggedIn = !!(await authClient.getSession()).data
+}}>
+    {#if loggedIn}
         <OverflowMenuItem text="Account" href="/account"/>
         <OverflowMenuItem text="Sign Out" href="/sign-out"/>
     {:else}

--- a/src/lib/components/header/AccountDropdown.svelte
+++ b/src/lib/components/header/AccountDropdown.svelte
@@ -3,15 +3,15 @@ import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
 import { User } from "carbon-icons-svelte";
 import { authClient } from "$lib/auth-client";
 
-let loggedIn = $state(false);
+let signedIn = $state(false);
 let open = $state(false);
 </script>
 
 <OverflowMenu bind:open={open} icon={User} flipped on:click={async () => {
-    if (open) return;
-    loggedIn = !!(await authClient.getSession()).data
+    if (open) return; // only check when opening the menu
+    signedIn = !!(await authClient.getSession()).data
 }}>
-    {#if loggedIn}
+    {#if signedIn}
         <OverflowMenuItem text="Account" href="/account"/>
         <OverflowMenuItem text="Sign Out" href="/sign-out"/>
     {:else}


### PR DESCRIPTION
There is an issue where the `useSession` is not reactive to authentication changes in these scenarios:
- If sign in is called server side, `useSession` does not react.
- If sign out is called server side or client side, `useSession` does not react.

For the former issue, it is an architectural issue with better-auth.
For the latter, it is more likely a bug.
For now, create a workaround that refetches the session every time the `AccountDropdown` is clicked.